### PR TITLE
Merge upstream from Lineageos/android_xiaomi_device_ido. Add a few strings to pass the SafetyNet Check.

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -174,9 +174,6 @@ TARGET_RIL_VARIANT := caf
 include device/qcom/sepolicy/sepolicy.mk
 BOARD_SEPOLICY_DIRS += $(LOCAL_PATH)/sepolicy
 
-# Seccomp
-BOARD_SECCOMP_POLICY += $(LOCAL_PATH)/seccomp
-
 # Video
 TARGET_HAVE_SIGNED_VENUS_FW := true
 

--- a/seccomp/mediacodec-seccomp.policy
+++ b/seccomp/mediacodec-seccomp.policy
@@ -1,3 +1,0 @@
-# device specific syscalls
-# extension of services/mediacodec/minijail/seccomp_policy/mediacodec-seccomp-arm.policy
-getdents64: 1

--- a/system.prop
+++ b/system.prop
@@ -120,3 +120,13 @@ persist.timed.enable=true
 
 # WIFI
 wifi.interface=wlan0
+
+# Make this device to pass the SafetyNet Check
+# Make Play Store to regard this device as ceritified.
+ro.build.fingerprint=Xiaomi/ido/ido:5.1.1/LMY47V/V8.1.1.0.LAICNDI:user/release-keys
+ro.build.description=ido-user 5.1.1 LMY47V V8.1.1.0.LAICNDI release-keys
+ro.opa.eligible_device=true
+keyguard.no_require_sim=true
+ro.com.google.clientidbase=android-xiaomi
+ro.bootimage.build.fingerprint=Xiaomi/lineage_ido/ido:7.1.2/N2G47E/b499157bec:userdebug/release-keys
+# **Maybe you need to modify the buildinfo.sh**


### PR DESCRIPTION
Merge upstream from Lineageos/android_xiaomi_device_ido.
Reverted d04538c.

Add a few strings to pass the SafetyNet Check.
See the commit message in Commit 4219401.
Maybe you need to modify build/tools/buildinfo.sh.