### PR TITLE
ido: Import build fingerprint from V8.1.1.0.LAICNDI China Stable

### DIFF
--- a/lineage.mk
+++ b/lineage.mk
@@ -24,3 +24,10 @@ PRODUCT_NAME := lineage_ido
 BOARD_VENDOR := Xiaomi
 
 PRODUCT_GMS_CLIENTID_BASE := android-xiaomi
+
+# Build fingerprint
+PRODUCT_BUILD_PROP_OVERRIDES += \
+    BUILD_FINGERPRINT="Xiaomi/ido/ido:5.1.1/LMY47V/V8.1.1.0.LAICNDI:user/release-keys" \
+    PRIVATE_BUILD_DESC="ido-user 5.1.1 LMY47V V8.1.1.0.LAICNDI release-keys"
+
+


### PR DESCRIPTION
* Xiaomi/ido/ido:5.1.1/LMY47V/V8.1.1.0.LAICNDI:user/release-keys
* We can't use Global Stable's fingerprint since it fails SafetyNet check.

Change-Id: I1a926fcf8f3083187ed38061e87894360e2919ea
Signed-off-by: Albert I <krascgq@outlook.co.id>

------- Just Copy that -------